### PR TITLE
docs: add package descriptions and licenses

### DIFF
--- a/src/forward/ecal2ros/package.xml
+++ b/src/forward/ecal2ros/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>ecal2ros</name>
   <version>0.2.0</version>
-  <description>TODO: Package description</description>
+  <description>Bridge eCAL image data to ROS 2 compressed image topics</description>
   <maintainer email="pengcheng@jushenzhiren.com">firefly</maintainer>
-  <license>TODO: License declaration</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/src/interface/robots_dog_msgs/package.xml
+++ b/src/interface/robots_dog_msgs/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>robots_dog_msgs</name>
   <version>0.2.0</version>
-  <description>TODO: Package description</description>
+  <description>Message and service definitions for robot dog communication in ROS 2</description>
   <maintainer email="kanon@todo.todo">kanon</maintainer>
-  <license>TODO: License declaration</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>std_msgs</buildtool_depend>

--- a/src/navigation/src/navIgo_behaviors/package.xml
+++ b/src/navigation/src/navIgo_behaviors/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_behaviors</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>Navigation behaviors and action plugins for the Navigo stack</description>
   <maintainer email="carlos.a.orduno@intel.com">Carlos Orduno</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <license>Apache-2.0</license>

--- a/src/navigation/src/navigo_behavior_tree/package.xml
+++ b/src/navigation/src/navigo_behavior_tree/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_behavior_tree</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>Behavior Tree nodes and plugins for the Navigo navigation system</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <maintainer email="carlos.a.orduno@intel.com">Carlos Orduno</maintainer>
   <maintainer email="mohammad.haghighipanah@intel.com">Carlos Orduno</maintainer>

--- a/src/navigation/src/navigo_bt_navigator/package.xml
+++ b/src/navigation/src/navigo_bt_navigator/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_bt_navigator</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>Behavior tree-based navigation action server for the Navigo stack</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <license>Apache-2.0</license>
 

--- a/src/navigation/src/navigo_navfn_planner/package.xml
+++ b/src/navigation/src/navigo_navfn_planner/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_navfn_planner</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>NavFn-based global planner plugin for the Navigo navigation stack</description>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <maintainer email="carlos.a.orduno@intel.com">Carlos Orduno</maintainer>
   <license>Apache-2.0</license>

--- a/src/navigation/src/navigo_path_planner/package.xml
+++ b/src/navigation/src/navigo_path_planner/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_path_planner</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>Global path planning server for the Navigo navigation stack</description>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <license>Apache-2.0</license>
 

--- a/src/navigation/src/navigo_util/package.xml
+++ b/src/navigation/src/navigo_util/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>navigo_util</name>
   <version>1.1.18</version>
-  <description>TODO</description>
+  <description>Utilities and lifecycle helpers for the Navigo navigation stack</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <maintainer email="mohammad.haghighipanah@intel.com">Mohammad Haghighipanah</maintainer>
   <license>Apache-2.0</license>

--- a/src/navigation/src/robot_navigo/package.xml
+++ b/src/navigation/src/robot_navigo/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>robot_navigo</name>
   <version>0.3.6</version>
-  <description>TODO: Package description</description>
+  <description>Bringup and launch files for running the Navigo navigation stack on a robot</description>
   <maintainer email="lingyihu@navigo.com">lingyihu</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
## Summary
- fill in package descriptions for navigo and interface packages
- specify BSD-3-Clause or Apache-2.0 licenses where missing

## Testing
- `ament_lint_auto` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aea62913088327bde7221b392e8e95